### PR TITLE
Add support for ZHA zigbee IR remotes as controller

### DIFF
--- a/docs/CLIMATE.md
+++ b/docs/CLIMATE.md
@@ -9,7 +9,7 @@ Find your device's brand code [here](CLIMATE.md#available-codes-for-climate-devi
 | `name`                       | string  | optional | The name of the device                                                                                                                                                                                                                                                                                                                                                         |
 | `unique_id`                  | string  | optional | An ID that uniquely identifies this device. If two devices have the same unique ID, Home Assistant will raise an exception.                                                                                                                                                                                                                                                    |
 | `device_code`                | number  | required | (Accepts only positive numbers)                                                                                                                                                                                                                                                                                                                                                |
-| `controller_data`            | string  | required | The data required for the controller to function. Enter the entity_id of the Broadlink remote **(must be an already configured device)**, or the entity id of the Xiaomi IR controller, or the MQTT topic on which to send commands.                                                                                                                                           |
+| `controller_data`            | string  | required | The data required for the controller to function. Enter the entity_id of the Broadlink remote **(must be an already configured device)**, or the entity id of the Xiaomi IR controller, or the MQTT topic on which to send commands, or the ZHA zigbee cluster to send commands to.                                                                                            |
 | `delay`                      | number  | optional | Adjusts the delay in seconds between multiple commands. The default is 0.5                                                                                                                                                                                                                                                                                                     |
 | `temperature_sensor`         | string  | optional | *entity_id* for a temperature sensor                                                                                                                                                                                                                                                                                                                                           |
 | `humidity_sensor`            | string  | optional | *entity_id* for a humidity sensor                                                                                                                                                                                                                                                                                                                                              |
@@ -71,6 +71,26 @@ climate:
     unique_id: office_ac
     device_code: 4000
     controller_data: 192.168.10.10
+    temperature_sensor: sensor.temperature
+    humidity_sensor: sensor.humidity
+    power_sensor: binary_sensor.ac_power
+```
+
+## Example (using ZHA controller and a TuYa ZS06):
+```yaml
+climate:
+  - platform: smartir
+    name: Office AC
+    unique_id: office_ac
+    device_code: 9000
+    controller_data: '{
+      "ieee":"XX:XX:XX:XX:XX:XX:XX:XX",
+      "endpoint_id": 1,
+      "cluster_id": 57348,
+      "cluster_type": "in",
+      "command": 2,
+      "command_type": "server"
+    }'
     temperature_sensor: sensor.temperature
     humidity_sensor: sensor.humidity
     power_sensor: binary_sensor.ac_power

--- a/docs/FAN.md
+++ b/docs/FAN.md
@@ -9,7 +9,7 @@ Find your device's brand code [here](FAN.md#available-codes-for-fan-devices) and
 | `name`                       | string  | optional | The name of the device                                                                                                                                                                                                                                                                                                                    |
 | `unique_id`                  | string  | optional | An ID that uniquely identifies this device. If two devices have the same unique ID, Home Assistant will raise an exception.                                                                                                                                                                                                               |
 | `device_code`                | number  | required | (Accepts only positive numbers)                                                                                                                                                                                                                                                                                                           |
-| `controller_data`            | string  | required | The data required for the controller to function. Enter the entity_id of the Broadlink remote **(must be an already configured device)**, or the entity id of the Xiaomi IR controller, or the MQTT topic on which to send commands.                                                                                                      |
+| `controller_data`            | string  | required | The data required for the controller to function. Enter the entity_id of the Broadlink remote **(must be an already configured device)**, or the entity id of the Xiaomi IR controller, or the MQTT topic on which to send commands, or the ZHA zigbee cluster to send commands to.                                                       |
 | `delay`                      | number  | optional | Adjusts the delay in seconds between multiple commands. The default is 0.5                                                                                                                                                                                                                                                                |
 | `power_sensor`               | string  | optional | *entity_id* for a sensor that monitors whether your device is actually `on` or `off`. This may be a power monitor sensor. (Accepts only on/off states)                                                                                                                                                                                    |
 | `power_sensor_restore_state` | boolean | optional | If `power_sensor` is set, and the device is likely to decrease power consumption bellow `power_sensors` threshold (for instance, a fan with speed in auto fluctuating mode), setting this to `true` will cause the entity fan state to update dynamically between OFF and last known ON speed, following the state of the `power_sensor`. |
@@ -101,6 +101,25 @@ fan:
     unique_id: bedroom_fan
     device_code: 4000
     controller_data: my_espir_send_raw_command
+    power_sensor: binary_sensor.fan_power
+```
+
+## Example (using ZHA controller and a TuYa ZS06):
+
+```yaml
+fan:
+  - platform: smartir
+    name: Bedroom fan
+    unique_id: bedroom_fan
+    device_code: 5000
+    controller_data: '{
+     "ieee":"XX:XX:XX:XX:XX:XX:XX:XX",
+     "endpoint_id": 1,
+     "cluster_id": 57348,
+     "cluster_type": "in",
+     "command": 2,
+     "command_type": "server"
+    }'
     power_sensor: binary_sensor.fan_power
 ```
 

--- a/docs/MEDIA_PLAYER.md
+++ b/docs/MEDIA_PLAYER.md
@@ -4,15 +4,15 @@ For this platform to work, we need a .json file containing all the necessary IR 
 Find your device's brand code [here](MEDIA_PLAYER.md#available-codes-for-tv-devices) and add the number in the `device_code` field. If your device is not working, you will need to learn your own codes and place the .json file in `smartir/custom_codes/media_player/` subfolders. Please note that the `device_code` field only accepts positive numbers. The .json extension is not required.
 
 ## Configuration variables:
-| Name              |  Type  | Default  | Description                                                                                                                                                                                                                          |
-| ----------------- | :----: | :------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `name`            | string | optional | The name of the device                                                                                                                                                                                                               |
-| `unique_id`       | string | optional | An ID that uniquely identifies this device. If two devices have the same unique ID, Home Assistant will raise an exception.                                                                                                          |
-| `device_code`     | number | required | (Accepts only positive numbers)                                                                                                                                                                                                      |
-| `controller_data` | string | required | The data required for the controller to function. Enter the entity_id of the Broadlink remote **(must be an already configured device)**, or the entity id of the Xiaomi IR controller, or the MQTT topic on which to send commands. |
-| `delay`           | number | optional | Adjusts the delay in seconds between multiple commands. The default is 0.5                                                                                                                                                           |
-| `power_sensor`    | string | optional | *entity_id* for a sensor that monitors whether your device is actually `on` or `off`. This may be a power monitor sensor. (Accepts only on/off states)                                                                               |
-| `source_names`    |  dict  | optional | Override the names of sources as displayed in HomeAssistant (see below)                                                                                                                                                              |
+| Name              |  Type  | Default  | Description                                                                                                                                                                                                                                                                         |
+| ----------------- | :----: | :------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`            | string | optional | The name of the device                                                                                                                                                                                                                                                              |
+| `unique_id`       | string | optional | An ID that uniquely identifies this device. If two devices have the same unique ID, Home Assistant will raise an exception.                                                                                                                                                         |
+| `device_code`     | number | required | (Accepts only positive numbers)                                                                                                                                                                                                                                                     |
+| `controller_data` | string | required | The data required for the controller to function. Enter the entity_id of the Broadlink remote **(must be an already configured device)**, or the entity id of the Xiaomi IR controller, or the MQTT topic on which to send commands, or the ZHA zigbee cluster to send commands to. |
+| `delay`           | number | optional | Adjusts the delay in seconds between multiple commands. The default is 0.5                                                                                                                                                                                                          |
+| `power_sensor`    | string | optional | *entity_id* for a sensor that monitors whether your device is actually `on` or `off`. This may be a power monitor sensor. (Accepts only on/off states)                                                                                                                              |
+| `source_names`    |  dict  | optional | Override the names of sources as displayed in HomeAssistant (see below)                                                                                                                                                                                                             |
 
 ## Example (using broadlink controller):
 Add a Broadlink RM device named "Bedroom" via config flow (read the [docs](https://www.home-assistant.io/integrations/broadlink/)).
@@ -94,6 +94,24 @@ media_player:
     unique_id: living_room_tv
     device_code: 2000
     controller_data: my_espir_send_raw_command
+    power_sensor: binary_sensor.tv_power
+```
+
+## Example (using ZHA controller and a TuYa ZS06):
+```yaml
+media_player:
+  - platform: smartir
+    name: Living room TV
+    unique_id: living_room_tv
+    device_code: 5000
+    controller_data: '{
+     "ieee":"XX:XX:XX:XX:XX:XX:XX:XX",
+     "endpoint_id": 1,
+     "cluster_id": 57348,
+     "cluster_type": "in",
+     "command": 2,
+     "command_type": "server"
+    }'
     power_sensor: binary_sensor.tv_power
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ SmartIR currently supports the following controllers:
 * [LOOK.in Remote](http://look-in.club/devices/remote)
 * [ESPHome User-defined service for remote transmitter](https://esphome.io/components/api.html#user-defined-services)
 * [MQTT Publish service](https://www.home-assistant.io/docs/mqtt/service/)
+* [ZHA Zigbee IR remote](https://www.home-assistant.io/integrations/zha/) (May require custom zha quirk for given controller)
 
 More than 120 climate devices are currently supported out-of-the-box, mainly for the Broadlink controller, thanks to our awesome community.
 

--- a/info.md
+++ b/info.md
@@ -5,6 +5,7 @@ SmartIR currently supports the following controllers:
 * [LOOK.in Remote](http://look-in.club/devices/remote)
 * [ESPHome User-defined service for remote transmitter](https://esphome.io/components/api.html#user-defined-services)
 * [MQTT Publish service](https://www.home-assistant.io/docs/mqtt/service/)
+* [ZHA Zigbee IR remote](https://www.home-assistant.io/integrations/zha/) (May require custom zha quirk for given controller)
 
 More than 120 climate devices are currently supported out-of-the-box, mainly for the Broadlink controller, thanks to our awesome community.<br>
 Please don't forget to [**star**](https://github.com/smartHomeHub/SmartIR/) the repository if you had fun! [**"Buy Me A Coffee**"](https://www.buymeacoffee.com/vassilis) is also welcome. It will help in further development.<br>


### PR DESCRIPTION
Add support for ZHA zigbee IR remotes as controller, based on original [PR1178](https://github.com/smartHomeHub/SmartIR/pull/1178), thansks to @anmar