### PR TITLE
Support ufo-r11 controller

### DIFF
--- a/custom_components/smartir/controller.py
+++ b/custom_components/smartir/controller.py
@@ -216,7 +216,7 @@ class ZHAController(AbstractController):
         )
 
 
-class UFOR11Controller(AbstractController):
+class UFOR11Controller(MQTTController):
     """Controls a UFO-R11 device."""
 
     def check_encoding(self, encoding):

--- a/custom_components/smartir/controller.py
+++ b/custom_components/smartir/controller.py
@@ -13,6 +13,7 @@ MQTT_CONTROLLER = "MQTT"
 LOOKIN_CONTROLLER = "LOOKin"
 ESPHOME_CONTROLLER = "ESPHome"
 ZHA_CONTROLLER = "ZHA"
+UFOR11_CONTROLLER = "UFOR11"
 
 ENC_BASE64 = "Base64"
 ENC_HEX = "Hex"
@@ -25,6 +26,7 @@ MQTT_COMMANDS_ENCODING = [ENC_RAW]
 LOOKIN_COMMANDS_ENCODING = [ENC_PRONTO, ENC_RAW]
 ESPHOME_COMMANDS_ENCODING = [ENC_RAW]
 ZHA_COMMANDS_ENCODING = [ENC_RAW]
+UFOR11_COMMANDS_ENCODING = [ENC_RAW]
 
 
 def get_controller(hass, controller, encoding, controller_data, delay):
@@ -36,6 +38,7 @@ def get_controller(hass, controller, encoding, controller_data, delay):
         LOOKIN_CONTROLLER: LookinController,
         ESPHOME_CONTROLLER: ESPHomeController,
         ZHA_CONTROLLER: ZHAController,
+        UFOR11_CONTROLLER: UFOR11Controller,
     }
     try:
         return controllers[controller](
@@ -211,6 +214,24 @@ class ZHAController(AbstractController):
         await self.hass.services.async_call(
             "zha", "issue_zigbee_cluster_command", service_data
         )
+
+
+class UFOR11Controller(AbstractController):
+    """Controls a UFO-R11 device."""
+
+    def check_encoding(self, encoding):
+        """Check if the encoding is supported by the controller."""
+        if encoding not in UFOR11_COMMANDS_ENCODING:
+            raise Exception("The encoding is not supported by the UFO-R11 controller.")
+
+    async def send(self, command):
+        """Send a command."""
+        service_data = {
+            "topic": self._controller_data,
+            "payload": json.dumps({"ir_code_to_send": command}),
+        }
+
+        await self.hass.services.async_call("mqtt", "publish", service_data)
 
 
 class Helper:

--- a/docs/CLIMATE.md
+++ b/docs/CLIMATE.md
@@ -49,7 +49,7 @@ climate:
     power_sensor: binary_sensor.ac_power
 ```
 
-## Example (using mqtt controller):
+## Example (using mqtt/Z06/UFO-R11 controller):
 ```yaml
 climate:
   - platform: smartir

--- a/docs/FAN.md
+++ b/docs/FAN.md
@@ -28,7 +28,6 @@ fan:
 ```
 
 ## Example (using xiaomi controller)
-
 ```yaml
 remote:
   - platform: xiaomi_miio
@@ -44,8 +43,7 @@ fan:
     power_sensor: binary_sensor.fan_power
 ```
 
-## Example (using mqtt controller)
-
+## Example (using mqtt/Z06/UFO-R11 controller)
 ```yaml
 fan:
   - platform: smartir
@@ -57,7 +55,6 @@ fan:
 ```
 
 ## Example (using LOOKin controller)
-
 ```yaml
 fan:
   - platform: smartir
@@ -69,9 +66,7 @@ fan:
 ```
 
 ## Example (using ESPHome)
-
 ESPHome configuration example:
-
 ```yaml
 esphome:
   name: my_espir
@@ -93,7 +88,6 @@ remote_transmitter:
 ```
 
 HA configuration.yaml:
-
 ```yaml
 fan:
   - platform: smartir
@@ -105,7 +99,6 @@ fan:
 ```
 
 ## Example (using ZHA controller and a TuYa ZS06):
-
 ```yaml
 fan:
   - platform: smartir

--- a/docs/MEDIA_PLAYER.md
+++ b/docs/MEDIA_PLAYER.md
@@ -43,7 +43,7 @@ media_player:
     power_sensor: binary_sensor.tv_power
 ```
 
-## Example (using mqtt controller):
+## Example (using mqtt/Z06/UFO-R11 controller):
 ```yaml
 media_player:
   - platform: smartir

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ SmartIR currently supports the following controllers:
 * [LOOK.in Remote](http://look-in.club/devices/remote)
 * [ESPHome User-defined service for remote transmitter](https://esphome.io/components/api.html#user-defined-services)
 * [MQTT Publish service](https://www.home-assistant.io/docs/mqtt/service/)
+  * [Tuya Z06/Moes UFO-R11](https://www.zigbee2mqtt.io/devices/UFO-R11.html) 
 * [ZHA Zigbee IR remote](https://www.home-assistant.io/integrations/zha/) (May require custom zha quirk for given controller)
 
 More than 120 climate devices are currently supported out-of-the-box, mainly for the Broadlink controller, thanks to our awesome community.

--- a/info.md
+++ b/info.md
@@ -5,6 +5,7 @@ SmartIR currently supports the following controllers:
 * [LOOK.in Remote](http://look-in.club/devices/remote)
 * [ESPHome User-defined service for remote transmitter](https://esphome.io/components/api.html#user-defined-services)
 * [MQTT Publish service](https://www.home-assistant.io/docs/mqtt/service/)
+  * [Tuya Z06/Moes UFO-R11](https://www.zigbee2mqtt.io/devices/UFO-R11.html) 
 * [ZHA Zigbee IR remote](https://www.home-assistant.io/integrations/zha/) (May require custom zha quirk for given controller)
 
 More than 120 climate devices are currently supported out-of-the-box, mainly for the Broadlink controller, thanks to our awesome community.<br>


### PR DESCRIPTION
added support for Tuya Z06/Moes UFO-R11 zigbee2mqtt controllers to close #12 