### PR TITLE
Ensure AUTO mode matches HVAC capabilities

### DIFF
--- a/custom_components/smartir/climate.py
+++ b/custom_components/smartir/climate.py
@@ -852,6 +852,7 @@ class SmartIRClimate(ClimateEntity, RestoreEntity):
             )
             and self._current_temperature is not None
             and self._current_temperature < self._target_temperature
+            and HVACMode.HEAT in self._hvac_modes
         ):
             self._hvac_action = HVACAction.HEATING
         elif (
@@ -862,6 +863,7 @@ class SmartIRClimate(ClimateEntity, RestoreEntity):
             )
             and self._current_temperature is not None
             and self._current_temperature > self._target_temperature
+            and HVACMode.COOL in self._hvac_modes
         ):
             self._hvac_action = HVACAction.COOLING
         elif (


### PR DESCRIPTION
In AUTO mode, devices could incorrectly display HEATING when the set temperature was above the target, even if they weren't capable of heating. Now, unsupported modes will display as IDLE instead.