### PR TITLE
Warm-up and cool-down delays in media players

### DIFF
--- a/custom_components/smartir/media_player.py
+++ b/custom_components/smartir/media_player.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-
+import time
 import voluptuous as vol
 
 from homeassistant.components.media_player import MediaPlayerEntity, PLATFORM_SCHEMA
@@ -93,6 +93,7 @@ class SmartIRMediaPlayer(MediaPlayerEntity, RestoreEntity):
         self._support_flags = 0
         self._power_sensor_check_expect = None
         self._power_sensor_check_cancel = None
+        self._ready_at = None
 
         self._manufacturer = device_data["manufacturer"]
         self._supported_models = device_data["supportedModels"]
@@ -156,6 +157,10 @@ class SmartIRMediaPlayer(MediaPlayerEntity, RestoreEntity):
             # Sources list
             for key in self._commands["sources"]:
                 self._sources_list.append(key)
+
+        # Initialization times
+        self._warm_up_delay = device_data['warmUpDelay'] if 'warmUpDelay' in device_data else None
+        self._cool_down_delay = device_data['coolDownDelay'] if 'coolDownDelay' in device_data else None
 
         # Init exclusive lock for sending IR commands
         self._temp_lock = asyncio.Lock()
@@ -253,7 +258,7 @@ class SmartIRMediaPlayer(MediaPlayerEntity, RestoreEntity):
         await self._send_command(STATE_OFF, [])
 
     async def async_turn_on(self):
-        """Turn the media player off."""
+        """Turn the media player on."""
         await self._send_command(STATE_ON, [])
 
     async def async_media_previous_track(self):
@@ -299,6 +304,8 @@ class SmartIRMediaPlayer(MediaPlayerEntity, RestoreEntity):
     async def _send_command(self, state, commands):
         async with self._temp_lock:
 
+            await self.wait_until_ready()
+
             if self._power_sensor and self._state != state:
                 self._async_power_sensor_check_schedule(state)
 
@@ -309,12 +316,17 @@ class SmartIRMediaPlayer(MediaPlayerEntity, RestoreEntity):
                             _LOGGER.error("Missing device IR code for 'on' command.")
                         else:
                             await self._controller.send(self._commands["on"])
+                            self._ready_at = time.monotonic() + max(self._warm_up_delay or 0, float(self._delay))
+
                     elif state == STATE_OFF:
                         if "off" not in self._commands.keys():
                             _LOGGER.error("Missing device IR code for 'off' command.")
                         else:
                             await self._controller.send(self._commands["off"])
-                    await asyncio.sleep(self._delay)
+                            self._ready_at = time.monotonic() + max(self._cool_down_delay or 0, float(self._delay))
+
+                    if commands:
+                        await self.wait_until_ready()
 
                 for keys in commands:
                     data = self._commands
@@ -371,6 +383,13 @@ class SmartIRMediaPlayer(MediaPlayerEntity, RestoreEntity):
                 self._state = STATE_OFF
                 # self._source = None
         self.async_write_ha_state()
+
+    async def wait_until_ready(self):
+        if self._ready_at:
+            time_to_wait = self._ready_at - time.monotonic()
+            if time_to_wait > 0:
+                await asyncio.sleep(time_to_wait)
+            self._ready_at = None
 
     @callback
     def _async_power_sensor_check_schedule(self, state):


### PR DESCRIPTION
Adds support for an additional delay when turning media players on/off.

I have some devices that cannot receive IR commands until some seconds after turning on. Same goes for turning off: it's not possible to send "turn-on" commands immediately after turning off.

Because of that it's impossible to make a script in HA that (1) turn on, (2) set source, (3) start playing, without adding explicit delays to the script.


Example definition:
```json
{
    "manufacturer":"Cambridge Audio",
    "supportedModels":[
        "551R"
    ],
    "warmUpDelay": 7,
    "coolDownDelay": 4,
    "supportedController":"ESPHome",
...
```

In this example, after being turned on from an off state,  subsequent commands will be delayed by 7 seconds. Turning off will block subsequent commands for 4 seconds.

## Implementation details
A simple way to implement this would be to simply do an additional delay after turn on/off commands. However, this create some unnecessary blocks. Instead, after the on/off call, it simply calculates at what time new commands can be processed. Then, any waiting is done in the preceding calls.