### PR TITLE
Extend docs for Z06/UFO-R11

### DIFF
--- a/docs/CLIMATE.md
+++ b/docs/CLIMATE.md
@@ -94,19 +94,6 @@ climate:
     power_sensor_restore_state: true
 ```
 
-It is important to notice that there are no MQTT codes in this repository. This means that to make it work, you need to convert codes from Broadlink format into MQTT format which fits Z06/UFO-R11 devices. Here is a step-by-step guide on how to do it:
-
-1. Download json file of code you need (1287.json in my case)
-2. Using https://gist.github.com/svyatogor/7839d00303998a9fa37eb48494dd680f?permalink_comment_id=5153002#gistcomment-5153002 convert code file
-
-example: `python3 broadlink_to_tuya.py 1287.json > 9997.json` (I have used 9997.json to differentiate it from original file)
-
-3. Change in 9997.json `MQTT` to `UFOR11`, like that
-
-`  "supportedController": "UFOR11",`
-
-4. Put it into custom_codes/climate, you can continue using 9997.json name if you wish
-
 ### Example (using LOOKin controller)
 
 ```yaml

--- a/docs/CLIMATE.md
+++ b/docs/CLIMATE.md
@@ -94,6 +94,19 @@ climate:
     power_sensor_restore_state: true
 ```
 
+It is important to notice that there are no MQTT codes in this repository. This means that to make it work, you need to convert codes from Broadlink format into MQTT format which fits Z06/UFO-R11 devices. Here is a step-by-step guide on how to do it:
+
+1. Download json file of code you need (1287.json in my case)
+2. Using https://gist.github.com/svyatogor/7839d00303998a9fa37eb48494dd680f?permalink_comment_id=5153002#gistcomment-5153002 convert code file
+
+example: `python3 broadlink_to_tuya.py 1287.json > 9997.json` (I have used 9997.json to differentiate it from original file)
+
+3. Change in 9997.json `MQTT` to `UFOR11`, like that
+
+`  "supportedController": "UFOR11",`
+
+4. Put it into custom_codes/climate, you can continue using 9997.json name if you wish
+
 ### Example (using LOOKin controller)
 
 ```yaml

--- a/docs/README.md
+++ b/docs/README.md
@@ -79,6 +79,12 @@ The resulting directory structure should look similar to this:
 
 To properly function, specification of your controlled device data including IR codes shall exists either in `codes` or in `custom_codes` directory as a .JSON file. When installed both using HACS or manual method, `codes` directory is populated by device data files maintained by this project. If you would like to create your own device data file, place it in the `custom_codes` class `climate|fan|media_player` subdirectory, this directory is persistent and will be manitained accross HACS updates. **Please don't forget to create [PR](https://github.com/litinoveweedle/SmartIR/pulls) for this new device data file and I will try to include it in a new releases.**
 
+### Convert IR Codes from Broadlink to Z06/UFO-R11
+
+Using https://gist.github.com/svyatogor/7839d00303998a9fa37eb48494dd680f?permalink_comment_id=5153002#gistcomment-5153002 you can convert Broadlink code file.
+
+Example: `python3 broadlink_to_tuya.py 1287.json > 9997.json` 
+
 ## Platform setup instructions
 
 Click on the links below for instructions on how to configure each platform.


### PR DESCRIPTION
As I have mentioned in this issue https://github.com/litinoveweedle/SmartIR/issues/117 docs are not complete enough for Z06/UFO-R11 devices, so here is a pull request which helps to make it work.