### PR TITLE
Improves light support

### DIFF
--- a/custom_components/smartir/light.py
+++ b/custom_components/smartir/light.py
@@ -345,9 +345,10 @@ class SmartIRLight(LightEntity, RestoreEntity):
         self.async_write_ha_state()
 
     async def async_turn_off(self):
-        self._state = STATE_OFF
-        await self.send_command(CMD_POWER_OFF)
-        self.async_write_ha_state()
+        if self._state != STATE_OFF:
+            self._state = STATE_OFF
+            await self.send_command(CMD_POWER_OFF)
+            self.async_write_ha_state()
 
     async def async_toggle(self):
         await (self.async_turn_on() if not self.is_on else self.async_turn_off())

--- a/custom_components/smartir/light.py
+++ b/custom_components/smartir/light.py
@@ -223,8 +223,20 @@ class SmartIRLight(LightEntity, RestoreEntity):
         # Turn the light on if off
         if self._state != STATE_ON and not self._on_by_remote:
             self._state = STATE_ON
-            did_something = True
-            await self.send_command(CMD_POWER_ON)
+            if CMD_POWER_ON in self._commands:
+                did_something = True
+                await self.send_command(CMD_POWER_ON)
+            else:
+                if ATTR_COLOR_TEMP_KELVIN not in params:
+                    _LOGGER.debug(
+                        f"No power on command found, setting last color {self._colortemp}K"
+                    )
+                    params[ATTR_COLOR_TEMP_KELVIN] = self._colortemp
+                if ATTR_BRIGHTNESS not in params:
+                    _LOGGER.debug(
+                        f"No power on command found, setting last brightness {self._brightness}"
+                    )
+                    params[ATTR_BRIGHTNESS] = self._brightness
 
         if (
             ATTR_COLOR_TEMP_KELVIN in params

--- a/custom_components/smartir/light.py
+++ b/custom_components/smartir/light.py
@@ -286,7 +286,7 @@ class SmartIRLight(LightEntity, RestoreEntity):
                         new_brightness == len(self._brightnesses) - 1
                         or new_brightness == 0
                     ):
-                        steps = len(self._colortemps)
+                        steps = len(self._brightnesses)
                     did_something = True
                     self._brightness = self._brightnesses[new_brightness]
                     await self.send_command(cmd, steps)

--- a/custom_components/smartir/light.py
+++ b/custom_components/smartir/light.py
@@ -47,7 +47,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Required(CONF_DEVICE_CODE): cv.positive_int,
         vol.Required(CONF_CONTROLLER_DATA): get_controller_schema(vol, cv),
-        vol.Optional(CONF_DELAY, default=DEFAULT_DELAY): cv.string,
+        vol.Optional(CONF_DELAY, default=DEFAULT_DELAY): cv.positive_float,
         vol.Optional(CONF_POWER_SENSOR): cv.entity_id,
         vol.Optional(
             CONF_POWER_SENSOR_DELAY, default=DEFAULT_POWER_SENSOR_DELAY
@@ -322,6 +322,7 @@ class SmartIRLight(LightEntity, RestoreEntity):
             try:
                 for _ in range(count):
                     await self._controller.send(remote_cmd)
+                    await asyncio.sleep(self._delay)
             except Exception as e:
                 _LOGGER.exception(e)
 

--- a/custom_components/smartir/light.py
+++ b/custom_components/smartir/light.py
@@ -242,6 +242,7 @@ class SmartIRLight(LightEntity, RestoreEntity):
             ATTR_COLOR_TEMP_KELVIN in params
             and ColorMode.COLOR_TEMP in self.supported_color_modes
         ):
+            did_something = True
             target = params.get(ATTR_COLOR_TEMP_KELVIN)
             old_color_temp = DeviceData.closest_match(self._colortemp, self._colortemps)
             new_color_temp = DeviceData.closest_match(target, self._colortemps)
@@ -254,7 +255,6 @@ class SmartIRLight(LightEntity, RestoreEntity):
                 _LOGGER.debug(
                     f"Changing color temp from {self._colortemp}K to {target}K using found remote command for {final_color_temp}K"
                 )
-                did_something = True
                 found_command = self._commands[CMD_COLORTEMPERATURE][final_color_temp]
                 self._colortemp = self._colortemps[new_color_temp]
                 await self.send_remote_command(found_command)
@@ -262,7 +262,6 @@ class SmartIRLight(LightEntity, RestoreEntity):
                 _LOGGER.debug(
                     f"Changing color temp from {self._colortemp}K step {old_color_temp} to {target}K step {new_color_temp}"
                 )
-
                 steps = new_color_temp - old_color_temp
                 if steps < 0:
                     cmd = CMD_COLORMODE_WARMER
@@ -276,7 +275,6 @@ class SmartIRLight(LightEntity, RestoreEntity):
                     # commands to go the full range.
                     if new_color_temp == len(self._colortemps) - 1 or new_color_temp == 0:
                         steps = len(self._colortemps)
-                    did_something = True
                     self._colortemp = self._colortemps[new_color_temp]
                     await self.send_command(cmd, steps)
 
@@ -290,6 +288,7 @@ class SmartIRLight(LightEntity, RestoreEntity):
                 await self.send_command(CMD_NIGHTLIGHT)
 
             elif self._brightnesses:
+                did_something = True
                 target = params.get(ATTR_BRIGHTNESS)
                 old_brightness = DeviceData.closest_match(
                     self._brightness, self._brightnesses
@@ -304,7 +303,6 @@ class SmartIRLight(LightEntity, RestoreEntity):
                     _LOGGER.debug(
                         f"Changing brightness from {self._brightness} to {target} using found remote command for {final_brightness}"
                     )
-                    did_something = True
                     found_command = self._commands[CMD_BRIGHTNESS][final_brightness]
                     self._brightness = self._brightnesses[new_brightness]
                     await self.send_remote_command(found_command)
@@ -328,7 +326,6 @@ class SmartIRLight(LightEntity, RestoreEntity):
                             or new_brightness == 0
                         ):
                             steps = len(self._brightnesses)
-                        did_something = True
                         self._brightness = self._brightnesses[new_brightness]
                         await self.send_command(cmd, steps)
 

--- a/docs/CODES_SYNTAX.md
+++ b/docs/CODES_SYNTAX.md
@@ -192,6 +192,106 @@ These are command to set controlled device into desired work state. Due to the n
                   },
   ```
 
+## Light Speficic
+
+### Light declaration part
+
+```yaml:
+    "brightness": [26, 51, 77, 102, 128, 153, 179, 204, 230, 255],
+    "colorTemperature": [
+      2700, 4600, 6500
+    ],
+```
+
+| json attribute    | mandatory |        type        | description                                                                                                                                                                                                                                                                                                                |
+| ----------------- | :-------: | :----------------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `brightness` |   `no`   |      `array of int`      | List of supported brightness levels for the light in the range of 0 to 255.                       |
+| `colorTemperature`  |   `yes`   |    `array of int`    | List of supported color temperatures for the light in Kelvin (K).                             |
+
+### Light commands
+
+#### Light `off` commands
+
+The off command specifies the IR code used to turn off the light. This command is necessary for any basic light control setup.
+
+```yaml:
+    "commands": {
+        "off": "JgCSAAABKHQKDGgHtSq.............",
+```
+
+#### Light `on` commands
+
+The on command is used to power on the device. In some cases, a dedicated on command is not required if the device can be turned on by setting a brightness or color temperature value.
+Since the device state is only assumed without a power sensor, it is highly recommended to use the power sensor feature in this case.
+
+```yaml:
+    "commands": {
+        "on": "JgCSAAABKHQKDGgHtSq.............",
+```
+
+#### Light `night` commands
+
+If a night command is specified, there is a special case when the requested brightness is 1, using the defined command:
+
+  ```yaml:
+  "commands": {
+      "night": "JgCSAAABKZIXEBcRFz.............",
+  ```
+
+#### Light brightness control
+
+The brightness control functionality enables dynamic adjustments to the light’s intensity. This can be achieved through general brighten and dim commands or by specifying individual commands for each supported brightness level.
+
+##### Light brighten and dim commands
+
+The brighten and dim commands incrementally adjust the brightness up or down, respectively.
+
+  ```yaml:
+  "commands": {
+      "brighten": "JgCSAAABKZIXEBcRFz.............",
+      "dim": "JgCSAAABKZIXEBcRFz.............",
+  ```
+
+##### Light brightness commands
+
+Alternatively, each supported brightness level can have a dedicated command.
+
+  ```yaml:
+  "commands": {
+      "brightness": {
+        "26": "JgCSAAABKZIXEBcRFz.............",
+        "51": "JgCSAAABKZIXEBcRFz.............",
+        ...
+      }
+  ```
+
+#### Light color temperature control
+
+Color temperature control allows users to adjust the warmth or coolness of the light. Similar to brightness, this can be managed with general commands or specific values.
+
+##### Light colder and warmer commands
+
+The colder and warmer commands provide a general way to adjust the color temperature incrementally.
+
+  ```yaml:
+  "commands": {
+      "colder": "JgCSAAABKZIXEBcRFz.............",
+      "warmer": "JgCSAAABKZIXEBcRFz.............",
+  ```
+
+##### Light colorTemperature commands
+
+Alternatively, commands can be defined for each supported color temperature value.
+
+  ```yaml:
+  "commands": {
+      "colorTemperature": {
+        "2700": "JgCSAAABKZIXEBcRFz.............",
+        "4600": "JgCSAAABKZIXEBcRFz.............",
+        "6500": "JgCSAAABKZIXEBcRFz.............",
+      }
+  ```
+
 ## Fan Speficic
 
 TBD


### PR DESCRIPTION
I added support to 2 lights I owns:
- The first one doesn't have colder/warmer commands, it has commands per specific color values. Also, it doesn't have an on command, you just send the brightness and color values and it turns on.
- The second one, as the first, it doesn't have colder/warmer commands, it has commands per specific color values. Also, it only has a toggle command for on/off.

Example:
```
{
    "manufacturer": "Sulion",
    "supportedModels": ["Marina S"],
    "supportedController": "ESPHome",
    "commandsEncoding": "Raw",
    "brightness": [26, 51, 77, 102, 128, 153, 179, 204, 230, 255],
    "colorTemperature": [
      2700, 4600, 6500
    ],
    "commands": {
      "off": "",
      "brighten": "",
      "dim": "",
      "colorTemperature": {
        "2700": "",
        "4600": "",
        "6500": ""
      }
    }
  }
```

### Enhancements:
* Added support for `CMD_COLORTEMPERATURE` and `CMD_BRIGHTNESS` commands to control color temperature and brightness, allowing specific commands per brightness or color values instead of up/down steps.
* Updated `async_turn_on` method to handle cases where `CMD_POWER_ON` is not available by setting the last known color temperature and brightness.
* Updated the `async_turn_off` method to check the current state before sending the power-off command.

### Bug Fixes:
* Use the delay config value when sending the command.
* Fix the brightness step calculation to use the correct value