### PR TITLE
add support for ChangHong KFR-35GW/DHR(W1-H)+2

### DIFF
--- a/codes/climate/3260.json
+++ b/codes/climate/3260.json
@@ -1,7 +1,7 @@
 {
   "manufacturer": "ChangHong",
   "supportedModels": [
-    "Unknown"
+    "KFR-35GW/DHR(W1-H)+2"
   ],
   "supportedController": "Xiaomi",
   "commandsEncoding": "Raw",


### PR DESCRIPTION
this pr works for me.only support Xiaomi IR Remote.I only own this ir device.